### PR TITLE
Fix: File opened without the with statement and Re-defined variable from outer scope

### DIFF
--- a/modules/aiutils.py
+++ b/modules/aiutils.py
@@ -287,7 +287,8 @@ async def upscale(c: Client, message: Message):
     i = await message.edit("<code>Processing...</code>")
 
     api_key = vca_api_key
-    image = open(photo_data, "rb").read()
+    with open(photo_data, "rb") as image_file:
+        image = image_file.read()
     upscaled_image_data = await upscale_request(api_key, image)
     with open("upscaled_image.png", "wb") as file:
         file.write(upscaled_image_data)

--- a/modules/aiutils.py
+++ b/modules/aiutils.py
@@ -314,7 +314,8 @@ async def whisp(message: Message):
                 await message.edit("<code>Processing...</code>")
 
                 api_key = vca_api_key
-                audio = open(audio_data, "rb").read()
+                with open(audio_data, "rb") as audio_file:
+                    audio = audio_file.read()
                 language = "auto"
                 task = "transcribe"
                 task_result = await transcribe_audio(api_key, audio, language, task)

--- a/modules/lexica.py
+++ b/modules/lexica.py
@@ -22,7 +22,8 @@ async def lupscale(client: Client, message: Message):
             await message.edit("<b>File not found</b>")
             return
     try:
-        image = open(photo_data, 'rb').read()
+        with open(photo_data, 'rb') as image_file:
+            image = image_file.read()
         upscaled_image = await UpscaleImages(image)
         if message.reply_to_message:
             message_id = message.reply_to_message.id

--- a/utils/scripts.py
+++ b/utils/scripts.py
@@ -191,13 +191,13 @@ def mediainfo(media):
     return m
 
 
-async def edit_or_reply(message, text):
+async def edit_or_reply(message, txt):
     """Edit Message If Its From Self, Else Reply To Message"""
     if not message:
-        return await message.edit(text)
+        return await message.edit(txt)
     if not message.from_user:
-        return await message.edit(text)
-    return await message.edit(text)
+        return await message.edit(txt)
+    return await message.edit(txt)
 
 
 def text(message: types.Message) -> str:

--- a/utils/scripts.py
+++ b/utils/scripts.py
@@ -69,27 +69,27 @@ def humanbytes(size):
 
 
 async def edit_or_send_as_file(
-    text: str,
+    tex: str,
     message: Message,
     client: Client,
     caption: str = "<code>Result!</code>",
     file_name: str = "result",
 ):
     """Send As File If Len Of Text Exceeds Tg Limit Else Edit Message"""
-    if not text:
+    if not tex:
         await message.edit("<code>Wait, What?</code>")
         return
-    if len(text) > 1024:
+    if len(tex) > 1024:
         await message.edit("<code>OutPut is Too Large, Sending As File!</code>")
-        file_names = f"{file_name}.text"
+        file_names = f"{file_name}.txt"
         with open(file_names, "w") as fn:
-            fn.write(text)
+            fn.write(tex)
         await client.send_document(message.chat.id, file_names, caption=caption)
         await message.delete()
         if os.path.exists(file_names):
             os.remove(file_names)
         return
-    return await message.edit(text)
+    return await message.edit(tex)
 
 
 def get_text(message: Message) -> [None, str]:

--- a/utils/scripts.py
+++ b/utils/scripts.py
@@ -82,7 +82,8 @@ async def edit_or_send_as_file(
     if len(text) > 1024:
         await message.edit("<code>OutPut is Too Large, Sending As File!</code>")
         file_names = f"{file_name}.text"
-        open(file_names, "w").write(text)
+        with open(file_names, "w") as fn:
+            fn.write(text)
         await client.send_document(message.chat.id, file_names, caption=caption)
         await message.delete()
         if os.path.exists(file_names):


### PR DESCRIPTION
Opening a file using `with` statement is preferred as function `open` implements the context manager protocol that releases the resource when it is outside of the `with` block. Not doing so requires you to manually release the resource.