### PR TITLE
Base of the cross-distro installer, some fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,10 +128,8 @@ If you're using Docker Compose version 2.x, use the following commands to start 
 > [!IMPORTANT]
 > Make Sure you add appropriate env vars
 
-## 🖥️ Self-hosted
+## 🖥️ Local Host
 ## 🐧 Linux (WSL compatible)
-
-### Update the packages
 
 ### Install Git
 There are instructions for installing on several different Unix distributions on the Git website, at https://git-scm.com/download/linux
@@ -150,18 +148,17 @@ chmod +x install.sh
 ./install.sh
 ```
 
-### Installer was tested on:
-- Arch Linux
+**Installer tested on:**
+- Arch
+- Debian
+- Ubuntu
+- WSL (APT based distros)
 
-[//]: # (- Debian)
-[//]: # (- Ubuntu)
-[//]: # (- etc.)
-
-Feel free to test on other distros and let us know if it works!
+Feel free to test on other distros and let us know!
 
 #### 📱 Termux 
 > [!TIP]
-> use [GitHub](https://github.com/termux/termux-app/releases) version
+> Use [GitHub](https://github.com/termux/termux-app/releases) version
 -------------------------------------------------------------------------------
 
 > **Full Installation instruction [Given here](https://telegra.ph/Moon-Userbot-Installation---Termux-02-09)**

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 [![License](https://img.shields.io/badge/License-GPL-pink)](https://github.com/The-MoonTg-project/Moon-Userbot/blob/main/LICENSE)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://makeapullrequest.com)
 
-</p>
+
 
 ***A Simple, Fast, Customizable, Ai powered Userbot for Telegram made after Dragon-Userbot abandoned***
 
@@ -128,23 +128,15 @@ If you're using Docker Compose version 2.x, use the following commands to start 
 > [!IMPORTANT]
 > Make Sure you add appropriate env vars
 
-## 🖥️ Local Host
-## Linux, Windows [only wsl]
+## 🖥️ Self-hosted
+## 🐧 Linux (WSL compatible)
 
 ### Update the packages
-
-```shell
-sudo apt update && sudo apt upgrade -y
-```
 
 ### Install Git
 
 > [!TIP]
-> Ignore if already installed
-
-```shell
-sudo apt install git
-```
+> Ensure you have the git installed
 
 ### Clone the repo
 
@@ -152,11 +144,22 @@ sudo apt install git
 git clone https://github.com/The-MoonTg-project/Moon-Userbot.git
 ```
 
-### Setup
+### Installation
 
 ```shell
-cd Moon-Userbot/ && sudo bash install.sh
+cd Moon-Userbot 
+chmod +x install.sh
+./install.sh
 ```
+
+### Installer was tested on:
+- Arch Linux
+
+[//]: # (- Debian)
+[//]: # (- Ubuntu)
+[//]: # (- etc.)
+
+Feel free to test on other distros and let us know if it works!
 
 #### 📱 Termux 
 > [!TIP]
@@ -198,15 +201,15 @@ Contributions of any type are welcome like `custom_modules` etc. Feel free to do
 ## Licence
 
 ```plaintext
-                    GNU GENERAL PUBLIC LICENSE
-                        Version 3, 29 June 2007
+                    GNU GENERAL PUBLIC LICENSE
+                        Version 3, 29 June 2007
 
-  Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
-  Everyone is permitted to copy and distribute verbatim copies
-  of this license document, but changing it is not allowed.
+  Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+  Everyone is permitted to copy and distribute verbatim copies
+  of this license document, but changing it is not allowed.
 
-                             Preamble
+                             Preamble
 
-   The GNU General Public License is a free, copyleft license for
- software and other kinds of works.
+   The GNU General Public License is a free, copyleft license for
+ software and other kinds of works.
 ```

--- a/README.md
+++ b/README.md
@@ -134,9 +134,7 @@ If you're using Docker Compose version 2.x, use the following commands to start 
 ### Update the packages
 
 ### Install Git
-
-> [!TIP]
-> Ensure you have the git installed
+There are instructions for installing on several different Unix distributions on the Git website, at https://git-scm.com/download/linux
 
 ### Clone the repo
 

--- a/install.sh
+++ b/install.sh
@@ -97,7 +97,7 @@ fi
 # PM PERMIT warn limit is the number of messages a user can receive from others before giving them a warning
 echo
 echo "SET PM PERMIT warn limit"
-#Now below is more clear version:
+# Now below is more clear version:
 echo "Enter the number of messages others can send you before receiving a warning, and eventually a ban or leave empty for default (3)"
 read -r -p "PM_LIMIT warn limit > " pm_limit
 

--- a/install.sh
+++ b/install.sh
@@ -63,13 +63,19 @@ if [[ -f ".env" ]] && [[ -f "my_account.session" ]]; then
   exit
 fi
 
-# Create a virtual environment inside the cloned repository and activate it
-python3 -m venv venv
-source venv/bin/activate
+# Prompt user if they want to proceed with creating a virtual environment
+echo "It's recommended to use a virtual environment for Python projects."
+echo "Note: If your drive resources are very limited, you might consider not creating a virtual environment, but it shouldn't be rejected otherwise unless you know what you're doing."
+read -r -p "Would you like to create a virtual environment? (Y/n) > " create_venv
 
-# Upgrade pip and install wheel and pillow
-pip install -U pip wheel pillow
+if [[ "$create_venv" != "n" ]] && [[ "$create_venv" != "N" ]]; then
+    # Create a virtual environment inside the cloned repository and activate it
+    python3 -m venv venv
+    source venv/bin/activate
 
+    # Upgrade pip and install wheel and pillow
+    pip install -U pip wheel pillow
+fi
 # Install Python requirements
 pip install -U -r requirements.txt || exit 2
 # Prompt for API_ID and API_HASH

--- a/install.sh
+++ b/install.sh
@@ -51,8 +51,8 @@ esac
 # Clone repository if not exists
 if [[ -d "Moon-Userbot" && "$(basename "$PWD")" != "Moon-Userbot" ]]; then
   cd Moon-Userbot || exit 2
-elif [[ "$(basename "$PWD")" == "Moon-Userbot" ]]; then
-  echo "Already in the correct repo, moving on."
+elif [[ "$(basename "$PWD")" == "Moon-Userbot" && -f ".env.dist" && -f "main.py" && -d "modules" ]]; then
+  echo "Already inside the Moon-Userbot repo, proceeding."
 else
   git clone https://github.com/The-MoonTg-project/Moon-Userbot || exit 2
   cd Moon-Userbot || exit 2
@@ -62,6 +62,7 @@ if [[ -f ".env" ]] && [[ -f "my_account.session" ]]; then
   echo "It seems that Moon-Userbot is already installed. Exiting..."
   exit
 fi
+
 # Create a virtual environment inside the cloned repository and activate it
 python3 -m venv venv
 source venv/bin/activate

--- a/install.sh
+++ b/install.sh
@@ -1,24 +1,58 @@
 #!/bin/bash
-if command -v termux-setup-storage; then
-  echo For termux, please use https://raw.githubusercontent.com/The-MoonTg-project/Moon-Userbot/main/termux-install.sh
-  exit 1
-fi
+PACKAGE_MANAGER=""
 
+# Ensure the script is run with root privileges
 if [[ $UID != 0 ]]; then
-  echo Please run this script as root
+  echo "This script requires root privileges."
+  echo "Please enter the root password to continue."
+  exec sudo "$0" "$@"
+else
+  echo "Running with root privileges"
+fi
+
+# Detect available package manager
+if command -v apt &>/dev/null; then
+  PACKAGE_MANAGER="apt"
+elif command -v apk &>/dev/null; then
+  PACKAGE_MANAGER="apk"
+elif command -v yum &>/dev/null; then
+  PACKAGE_MANAGER="yum"
+elif command -v pacman &>/dev/null; then
+  PACKAGE_MANAGER="pacman"
+else
+  echo "Unsupported package manager. Please use a compatible distribution or update the installer script."
   exit 1
 fi
 
-apt update -y
-apt install python3 python3-pip git ffmpeg wget gnupg -y || exit 2
+if command -v termux-setup-storage; then
+  echo "For termux, please use https://raw.githubusercontent.com/The-MoonTg-project/Moon-Userbot/main/termux-install.sh"
+  exit 1
+fi
 
-su -c "python3 -m pip install -U pip" $SUDO_USER
-su -c "python3 -m pip install -U wheel pillow" $SUDO_USER
+# Install necessary packages based on detected package manager
+case "$PACKAGE_MANAGER" in
+  apt)
+    apt update -y
+    apt install python3 python3-venv git wget -y || exit 2
+    ;;
+  apk)
+    apk update
+    apk add python3 py3-virtualenv git wget || exit 2 # Packages here may be wrong, to verify
+    ;;
+  yum)
+    yum update -y
+    yum install python3 python3-venv git wget -y || exit 2 # Packages here may be wrong, to verify
+    ;;
+  pacman)
+    pacman -S --noconfirm python python-virtualenv git wget || exit 2
+    ;;
+esac
 
-if [[ -d "Moon-Userbot" ]]; then
-  cd Moon-Userbot
-elif [[ -f ".env.dist" ]] && [[ -f "main.py" ]] && [[ -d "modules" ]]; then
-  :
+# Clone repository if not exists
+if [[ -d "Moon-Userbot" && "$(basename "$PWD")" != "Moon-Userbot" ]]; then
+  cd Moon-Userbot || exit 2
+elif [[ "$(basename "$PWD")" == "Moon-Userbot" ]]; then
+  echo "Already in the correct repo, moving on."
 else
   git clone https://github.com/The-MoonTg-project/Moon-Userbot || exit 2
   cd Moon-Userbot || exit 2
@@ -28,33 +62,53 @@ if [[ -f ".env" ]] && [[ -f "my_account.session" ]]; then
   echo "It seems that Moon-Userbot is already installed. Exiting..."
   exit
 fi
+# Create a virtual environment inside the cloned repository and activate it
+python3 -m venv venv
+source venv/bin/activate
 
-su -c "python3 -m pip install -U -r requirements.txt" $SUDO_USER || exit 2
+# Upgrade pip and install wheel and pillow
+pip install -U pip wheel pillow
 
+# Install Python requirements
+pip install -U -r requirements.txt || exit 2
+# Prompt for API_ID and API_HASH
 echo
 echo "Enter API_ID and API_HASH"
 echo "You can get it here -> https://my.telegram.org/"
-echo "Leave empty to use defaults (please note that default keys significantly increases your ban chances)"
+echo "Leave empty to use defaults (please note that using default keys is a **very bad idea** and significantly increases your ban chances)"
 read -r -p "API_ID > " api_id
 
+# Default API_ID and API_HASH
 if [[ $api_id = "" ]]; then
-  api_id="2040"
-  api_hash="b18441a1ff607e10a989891a5462e627"
+  echo "You have chosen to use the default API_ID and API_HASH, which is strongly discouraged."
+  echo "Please type 'I agree' to confirm that you understand the risks and still wish to proceed."
+  read -r -p "Confirmation > " confirmation
+  if [[ $confirmation = "I agree" ]]; then
+    api_id="2040"
+    api_hash="b18441a1ff607e10a989891a5462e627"
+  else
+    echo "Confirmation not provided. Exiting..."
+    exit 1
+  fi
 else
   read -r -p "API_HASH > " api_hash
 fi
-
+# Prompt for PM PERMIT warn limit
+# PM PERMIT warn limit is the number of messages a user can receive from others before giving them a warning
 echo
 echo "SET PM PERMIT warn limit"
+#Now below is more clear version:
+echo "Enter the number of messages others can send you before receiving a warning, and eventually a ban or leave empty for default (3)"
 read -r -p "PM_LIMIT warn limit > " pm_limit
 
 if [[ $pm_limit = "" ]]; then
   pm_limit="3"
-  echo "limit not provided by user set to default"
+  echo "Limit not provided by user; set to default"
 fi
 
+# Prompt for musicbot usage
 echo
-echo "Do you want to use musicbot? (y/n)"
+echo "Do you want to use musicbot? (y/N)"
 read -r -p "MUSIC_BOT > " musicbot
 if [[ $musicbot = "y" ]]; then
   echo
@@ -65,7 +119,7 @@ if [[ $musicbot = "y" ]]; then
     second_session=""
   else
     echo
-    echo "Please provide handler to be used by msuicbot"
+    echo "Please provide handler to be used by musicbot"
     read -r -p "MUSIC_HANDLER > " music_handler
     if [[ $music_handler = "" ]]; then
       echo "MUSIC_HANDLER not provided by user"
@@ -74,13 +128,13 @@ if [[ $musicbot = "y" ]]; then
   fi
 fi
 
-echo
+# Prompt for various API keys
 echo "Enter APIFLASH_KEY for webshot plugin"
 echo "You can get it here -> https://apiflash.com/dashboard/access_keys"
 read -r -p "APIFLASH_KEY > " apiflash_key
 
 if [[ $apiflash_key = "" ]]; then
-  echo "NOTE: API Not set you'll get errors with webshot & ws module"
+  echo "NOTE: API Not set; you'll get errors with webshot & ws module"
 fi
 
 echo
@@ -89,7 +143,7 @@ echo "You can get it here -> https://www.remove.bg/dashboard#api-key"
 read -r -p "RMBG_KEY > " rmbg_key
 
 if [[ $rmbg_key = "" ]]; then
-  echo "NOTE: API Not set you'll not be able to use remove background modules"
+  echo "NOTE: API Not set; you'll not be able to use remove background modules"
 fi
 
 echo
@@ -98,7 +152,7 @@ echo "You can get it here -> https://www.virustotal.com/"
 read -r -p "VT_KEY > " vt_key
 
 if [[ $vt_key = "" ]]; then
-  echo "NOTE: API Not set you'll not be able to use VirusTotal module"
+  echo "NOTE: API Not set; you'll not be able to use VirusTotal module"
 fi
 
 echo
@@ -107,7 +161,7 @@ echo "You can get it here -> https://makersuite.google.com/app/apikey"
 read -r -p "GEMINI_KEY > " gemini_key
 
 if [[ $gemini_key = "" ]]; then
-  echo "NOTE: API Not set you'll not be able to use Gemini AI modules"
+  echo "NOTE: API Not set; you'll not be able to use Gemini AI modules"
 fi
 
 echo
@@ -116,7 +170,7 @@ echo "You can get it here -> https://dashboard.cohere.com/api-keys"
 read -r -p "COHERE_KEY > " cohere_key
 
 if [[ $cohere_key = "" ]]; then
-  echo "NOTE: API Not set you'll not be able to use Coral AI modules"
+  echo "NOTE: API Not set; you'll not be able to use Coral AI modules"
 fi
 
 echo
@@ -125,47 +179,64 @@ echo "Learn How to Get One --> https://github.com/VisionCraft-org/VisionCraft?ta
 read -r -p "VCA_API_KEY > " vca_api_key
 
 if [[ $vca_api_key = "" ]]; then
-  echo "NOTE: API Not set you'll not be able to use aiutils module/pligins"
+  echo "NOTE: API Not set; you'll not be able to use aiutils module/plugins"
 fi
 
-echo
-echo "Choose database type:"
-echo "[1] MongoDB db_url"
-echo "[2] MongoDB localhost"
-echo "[3] Sqlite (default)"
-read -r -p "> " db_type
 
 echo
-case $db_type in
-  1)
-    echo "Please enter db_url"
-    echo "You can get it here -> https://mongodb.com/atlas"
-    read -r -p "> " db_url
-    db_name=Moon_Userbot
-    db_type=mongodb
-    ;;
-  2)
-    if systemctl status mongodb; then
-      wget -qO - https://www.mongodb.org/static/pgp/server-5.0.asc | apt-key add -
-      source /etc/os-release
-      echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu ${UBUNTU_CODENAME}/mongodb-org/5.0 multiverse" | tee /etc/apt/sources.list.d/mongodb-org-5.0.list
-      apt update
-      apt install mongodb -y
-      systemctl daemon-reload
-      systemctl enable mongodb
-    fi
-    systemctl start mongodb
+while true; do
+  # Prompt for database type and database URL if MongoDB is selected
+  echo
+  echo "Choose database type:"
+  echo "[1] MongoDB db_url"
+  echo "[2] MongoDB localhost"
+  echo "[3] Sqlite (default)"
+  read -r -p "> " db_type
 
-    db_url=mongodb://localhost:27017
-    db_name=Moon_Userbot
-    db_type=mongodb
-    ;;
-  *)
-    db_name=db.sqlite3
-    db_type=sqlite3
-    ;;
-esac
+  case $db_type in
+    1)
+      echo "Please enter db_url"
+      echo "You can get it here -> https://mongodb.com/atlas"
+      read -r -p "> " db_url
+      db_name=Moon_Userbot
+      db_type=mongodb
+      break
+      ;;
+    2)
+      if ! command -v apt &>/dev/null; then
+        echo "This option requires apt package manager, which is not available on your system."
+        echo "Please choose a different database type."
+        continue
+      fi
 
+      if systemctl status mongodb; then
+        wget -qO - https://www.mongodb.org/static/pgp/server-5.0.asc | apt-key add -
+        source /etc/os-release
+        echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu ${UBUNTU_CODENAME}/mongodb-org/5.0 multiverse" | tee /etc/apt/sources.list.d/mongodb-org-5.0.list
+        apt update
+        apt install mongodb -y
+        systemctl daemon-reload
+        systemctl enable mongodb
+      fi
+      systemctl start mongodb
+
+      db_url=mongodb://localhost:27017
+      db_name=Moon_Userbot
+      db_type=mongodb
+      break
+      ;;
+    *)
+      db_name=db.sqlite3
+      db_type=sqlite3
+      break
+      ;;
+    *)
+      echo "Invalid choice!"
+      ;;
+  esac
+done
+
+# Generate .env file with collected variables
 cat > .env << EOL
 API_ID=${api_id}
 API_HASH=${api_hash}
@@ -187,40 +258,53 @@ SECOND_SESSION=${second_session}
 MUSIC_HANDLER=${music_handler}
 EOL
 
+# Adjust the ownership of the Moon-Userbot directory
 chown -R $SUDO_USER:$SUDO_USER .
 
-echo
-echo "Choose installation type:"
-echo "[1] PM2"
-echo "[2] Systemd service"
-echo "[3] Custom (default)"
-read -r -p "> " install_type
+
 
 su -c "python3 install.py ${install_type}" $SUDO_USER || exit 3
 
-case $install_type in
-  1)
-    if ! command -v pm2; then
-      curl -fsSL https://deb.nodesource.com/setup_17.x | bash
-      apt install nodejs -y
-      npm install pm2 -g
-      su -c "pm2 startup" $SUDO_USER
-      env PATH=$PATH:/usr/bin /usr/lib/node_modules/pm2/bin/pm2 startup systemd -u $SUDO_USER --hp /home/$SUDO_USER
-    fi
-    su -c "pm2 start main.py --name Moon --interpreter python3" $SUDO_USER
-    su -c "pm2 save" $SUDO_USER
+# Configure the bot based on selected installation type
+while true; do
+  # Prompt for installation type and execute accordingly
+  echo
+  echo "Choose installation type:"
+  echo "[1] PM2"
+  echo "[2] Systemd service"
+  echo "[3] Custom (default)"
+  read -r -p "> " install_type
 
-    echo
-    echo "============================"
-    echo "Great! Moon-Userbot installed successfully and running now!"
-    echo "Installation type: PM2"
-    echo "Start with: \"pm2 start Moon\""
-    echo "Stop with: \"pm2 stop Moon\""
-    echo "Process name: Moon"
-    echo "============================"
-    ;;
-  2)
-    cat > /etc/systemd/system/Moon.service << EOL
+  case $install_type in
+    1)
+      if ! command -v apt &>/dev/null; then
+        echo "This option requires apt package manager, which is not available on your system."
+        echo "Please choose a different installation type."
+        continue
+      fi
+
+      if ! command -v pm2 &>/dev/null; then
+        curl -fsSL https://deb.nodesource.com/setup_17.x | bash
+        apt install nodejs -y
+        npm install pm2 -g
+        su -c "pm2 startup" $SUDO_USER
+        env PATH=$PATH:/usr/bin /usr/lib/node_modules/pm2/bin/pm2 startup systemd -u $SUDO_USER --hp /home/$SUDO_USER
+      fi
+      su -c "pm2 start main.py --name Moon --interpreter python3" $SUDO_USER
+      su -c "pm2 save" $SUDO_USER
+
+      echo
+      echo "============================"
+      echo "Great! Moon-Userbot installed successfully and running now!"
+      echo "Installation type: PM2"
+      echo "Start with: \"pm2 start Moon\""
+      echo "Stop with: \"pm2 stop Moon\""
+      echo "Process name: Moon"
+      echo "============================"
+      break
+      ;;
+    2)
+      cat > /etc/systemd/system/Moon.service << EOL
 [Unit]
 Description=Service for Moon Userbot
 [Service]
@@ -233,26 +317,33 @@ Group=${SUDO_USER}
 [Install]
 WantedBy=multi-user.target
 EOL
-    systemctl daemon-reload
-    systemctl start Moon
-    systemctl enable Moon
+      systemctl daemon-reload
+      systemctl start Moon
+      systemctl enable Moon
 
-    echo
-    echo "============================"
-    echo "Great! Moon-Userbot installed successfully and running now!"
-    echo "Installation type: Systemd service"
-    echo "Start with: \"sudo systemctl start Moon\""
-    echo "Stop with: \"sudo systemctl stop Moon\""
-    echo "============================"
-    ;;
-  *)
-    echo
-    echo "============================"
-    echo "Great! Moon-Userbot installed successfully!"
-    echo "Installation type: Custom"
-    echo "Start with: \"python3 main.py\""
-    echo "============================"
-    ;;
-esac
+      echo
+      echo "============================"
+      echo "Great! Moon-Userbot installed successfully and running now!"
+      echo "Installation type: Systemd service"
+      echo "Start with: \"sudo systemctl start Moon\""
+      echo "Stop with: \"sudo systemctl stop Moon\""
+      echo "============================"
+      break
+      ;;
+    3)
+      echo
+      echo "============================"
+      echo "Great! Moon-Userbot installed successfully!"
+      echo "Installation type: Custom"
+      echo "Start with: \"python3 main.py\""
+      echo "============================"
+      break
+      ;;
+    *)
+      echo "Invalid choice! Please enter 1, 2, or 3."
+      ;;
+  esac
+done
 
+# Adjust the ownership of the Moon-Userbot directory again as a final step
 chown -R $SUDO_USER:$SUDO_USER .

--- a/install.sh
+++ b/install.sh
@@ -232,7 +232,7 @@ while true; do
       db_type=mongodb
       break
       ;;
-    *)
+    3)
       db_name=db.sqlite3
       db_type=sqlite3
       break

--- a/install.sh
+++ b/install.sh
@@ -94,7 +94,7 @@ else
   read -r -p "API_HASH > " api_hash
 fi
 # Prompt for PM PERMIT warn limit
-# PM PERMIT warn limit is the number of messages a user can receive from others before giving them a warning
+# PM PERMIT warn limit is the number of messages a user can receive from others before giving them a warning, requires `antipm` plugin to be enabled
 echo
 echo "SET PM PERMIT warn limit"
 # Now below is more clear version:

--- a/install.sh
+++ b/install.sh
@@ -269,9 +269,6 @@ EOL
 chown -R $SUDO_USER:$SUDO_USER .
 
 
-
-su -c "python3 install.py ${install_type}" $SUDO_USER || exit 3
-
 # Configure the bot based on selected installation type
 while true; do
   # Prompt for installation type and execute accordingly
@@ -351,6 +348,8 @@ EOL
       ;;
   esac
 done
+
+  su -c "python3 install.py ${install_type}" $SUDO_USER || exit 3
 
 # Adjust the ownership of the Moon-Userbot directory again as a final step
 chown -R $SUDO_USER:$SUDO_USER .


### PR DESCRIPTION
Fix: Removed some weird characters and slightly improved README.md

Add: Installer asks for root if not provided instead of exiting it

Fix: Installer can determine which package manager it's running with and doesn't have to rely on specific distro

Fix: Installer won't let steps that require "apt" run and will return user to the selection menu, if host distro uses something else (this is a temporary fool-proof solution until the installation steps themselves can be improved to work on different distros)

Fix: Forced users to clearly agree to using default credentials if they don't provide API_ID/HASH, so they don't get banned by mistake and are well aware of the risks

Fix: Made some prompts more clear and easier to understand (At least the ones I was confused with and had to clarify about in chat)

